### PR TITLE
Change nodes_list method to get all nodes

### DIFF
--- a/lib/chef/knife/tidy_server_report.rb
+++ b/lib/chef/knife/tidy_server_report.rb
@@ -37,7 +37,7 @@ class Chef
           cb_list = cookbook_list(org)
           version_count = cookbook_count(cb_list).sort_by(&:last).reverse.to_h
           used_cookbooks = {}
-          nodes = nodes_list(org)[0]
+          nodes = nodes_list(org)
 
           nodes.select{|node| !node['cookbooks'].nil?}.each do |node|
             node['cookbooks'].each do |name, version_hash|
@@ -86,7 +86,10 @@ class Chef
         end
       end
 
+      # Need the block here to get the search method to invoke multiple searches and 
+      # aggregate results for result sets over 1k.
       def nodes_list(org)
+        node_results = []
         Chef::Search::Query.new("#{server.root_url}/organizations/#{org}").search(
           :node, '*:*',
           :filter_result => {
@@ -94,7 +97,10 @@ class Chef
             'cookbooks' => ['cookbooks'],
             'ohai_time' => ['ohai_time']
           }
-        )
+        ) do |node|
+          node_results << node
+        end
+        node_results
       end
 
       def cookbook_list(org)


### PR DESCRIPTION
Current implementation pulls only 1k nodes for the stale node list and
cookbook usage calculation.  The `search` method from
`Chef::Search::Query` can loop over multiple sets of results, but you
must pass it a block.  This change refactors `nodes_list` to use a
block and capture each node into an array, rather than returning the
raw results of the `search` method.

Thish as been verified to successfully pull a node list of more than 1k
nodes.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>