### PR TITLE
Add node_count to stale node json output.

### DIFF
--- a/lib/chef/knife/tidy_server_report.rb
+++ b/lib/chef/knife/tidy_server_report.rb
@@ -62,7 +62,7 @@ class Chef
             end
           end
 
-          stale_nodes_hash = {'threshold_days': node_threshold, 'count': stale_nodes.count, 'list': stale_nodes}
+          stale_nodes_hash = {'threshold_days': node_threshold, 'node_count': node.count, 'count': stale_nodes.count, 'list': stale_nodes}
           stale_orgs.push(org) if stale_nodes.count == nodes.count
 
           tidy.write_new_file(unused_cookbooks(used_cookbooks, cb_list), ::File.join(tidy.reports_dir, "#{org}_unused_cookbooks.json"))

--- a/lib/chef/knife/tidy_server_report.rb
+++ b/lib/chef/knife/tidy_server_report.rb
@@ -62,7 +62,7 @@ class Chef
             end
           end
 
-          stale_nodes_hash = {'threshold_days': node_threshold, 'node_count': node.count, 'count': stale_nodes.count, 'list': stale_nodes}
+          stale_nodes_hash = {'threshold_days': node_threshold, 'org_total_node_count': nodes.count, 'count': stale_nodes.count, 'list': stale_nodes}
           stale_orgs.push(org) if stale_nodes.count == nodes.count
 
           tidy.write_new_file(unused_cookbooks(used_cookbooks, cb_list), ::File.join(tidy.reports_dir, "#{org}_unused_cookbooks.json"))


### PR DESCRIPTION
To help make decisions when processing stale nodes having the total number of nodes available
is very helpful.