### PR TITLE
Set default encoding to utf-8 to properly handle non-ascii in backups.

### DIFF
--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -6,6 +6,8 @@ class Chef
     attr_accessor :backup_path
 
     def initialize(backup_path = Dir.pwd)
+      Encoding.default_external = Encoding::UTF_8
+      Encoding.default_internal = Encoding::UTF_8
       @backup_path = ::File.expand_path(backup_path)
     end
 


### PR DESCRIPTION
Signed-off-by: Josh Hudson <jhudson@chef.io>