### PR TITLE
Add option for backup path to server clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,13 @@ Remove stale nodes that haven't checked-in to the Chef Server as defined by the 
 ## Options
 
   * `--backup-path /path/to/an-ec-backup`
-    The location to the last backup of the Chef Server. It is not recommend to run the clean commnand without first taking a current backup using [knife-ec-backup](https://github.com/chef/knife-ec-backup)
-
-  * `--concurrency`
-    Number of simultaneous request being sent to the target Chef Server
+    The location to the last backup of the target Chef Server. It is not recommended to run the clean command without first taking a current backup using [knife-ec-backup](https://github.com/chef/knife-ec-backup)
 
   * `--only-cookbooks`
-    Only deletes the unused cookbooks from the target Chef Server. NOTE: Cannot be speciefied if `--only-nodes` is already specified
+    Only deletes the unused cookbooks from the target Chef Server. NOTE: Cannot be specified if `--only-nodes` is already specified
 
   * `--only-nodes`
-    Only deltes the stale nodes, associated clients, and ACLs from the target Chef Server. NOTE: Cannot be speciefied if `--only-cookbooks` is already specified
+    Only deltes the stale nodes, associated clients, and ACLs from the target Chef Server. NOTE: Cannot be specified if `--only-cookbooks` is already specified
 
   * `--dry-run`
     Do not perform any actual deletion, only report on what would have been deleted.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,19 @@ org_unused_cookbooks.json | List of cookbooks and versions that do not appear to
 ## $ knife tidy server clean --help
 Remove stale nodes that haven't checked-in to the Chef Server as defined by the `--node-threshold NUM_DAYS` option when the reports were generated.. The associated client and ACLs are also removed.
 
-Future: remove unused cookbooks - currently this feature is disabled.
-
 ## Options
+
+  * `--backup-path /path/to/an-ec-backup`
+    The location to the last backup of the Chef Server. It is not recommend to run the clean commnand without first taking a current backup using [knife-ec-backup](https://github.com/chef/knife-ec-backup)
+
+  * `--concurrency`
+    Number of simultaneous request being sent to the target Chef Server
+
+  * `--only-cookbooks`
+    Only deletes the unused cookbooks from the target Chef Server. NOTE: Cannot be speciefied if `--only-nodes` is already specified
+
+  * `--only-nodes`
+    Only deltes the stale nodes, associated clients, and ACLs from the target Chef Server. NOTE: Cannot be speciefied if `--only-cookbooks` is already specified
 
   * `--dry-run`
     Do not perform any actual deletion, only report on what would have been deleted.

--- a/lib/chef/knife/tidy_server_clean.rb
+++ b/lib/chef/knife/tidy_server_clean.rb
@@ -3,7 +3,6 @@ require 'chef/knife/tidy_base'
 class Chef
   class Knife
     class TidyServerClean < Knife
-
       include Knife::TidyBase
 
       deps do
@@ -12,6 +11,10 @@ class Chef
       end
 
       banner "knife tidy server clean (options)"
+
+      option :backup_path,
+        :long => '--backup-path path/to/backup',
+        :description => 'The path to the knife-ec-backup backup directory'
 
       option :concurrency,
         :long => '--concurrency THREADS',
@@ -40,6 +43,10 @@ class Chef
         if config[:only_cookbooks] && config[:only_nodes]
           ui.error 'Cannot use --only-cookbooks AND --only-nodes'
           exit 1
+        end
+
+        unless config[:backup_path]
+          config[:backup_path] = ui.ask_question("It is not recommended to run this command without specifying a current backup directory.\nPlease set a backup directory.\n")
         end
 
         deletions = if config[:only_cookbooks]

--- a/lib/chef/knife/tidy_server_clean.rb
+++ b/lib/chef/knife/tidy_server_clean.rb
@@ -45,8 +45,14 @@ class Chef
           exit 1
         end
 
-        unless config[:backup_path]
-          config[:backup_path] = ui.ask_question("It is not recommended to run this command without specifying a current backup directory.\nPlease set a backup directory.\n")
+        while config[:backup_path].nil?
+          user_value = ui.ask_question("It is not recommended to run this command without specifying a current backup directory.\nPlease set a backup directory.\n")
+          config[:backup_path] = user_value == '' ? nil : user_value
+        end
+
+        unless ::File.directory?(config[:backup_path])
+          ui.error 'Must specify valid --backup-path'
+          exit 1
         end
 
         deletions = if config[:only_cookbooks]


### PR DESCRIPTION
Added option for server clean to specify a backup path. If no backup path is specified the user is prompted once to specify a backup path. Also updated the README to show this option as well as the other options for server clean not listed in the README.

Signed-off-by: John Snow <thelunaticscripter@outlook.com>