### PR TITLE
fix empty clients group

### DIFF
--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -32,6 +32,10 @@ class Chef
       ::File.expand_path(::File.join(@backup_path, 'organizations', org, 'clients'))
     end
 
+    def client_names(org)
+      Dir[::File.join(clients_path(org), '*')].map { |dir| ::File.basename(dir, '.json') }
+    end
+
     def groups_path(org)
       ::File.expand_path(::File.join(@backup_path, 'organizations', org, 'groups'))
     end


### PR DESCRIPTION
## Description

This PR adds auto correction when the clients group either:
 * has no clients (Array) key
 * does not have all the clients that are in the org

## Background
oc_erchef has a timeout for oc_chef_authz connections that defaults to 2000ms.
For organizations with thousands of clients, this timeout can be exceeded. The result is a SQL timeout which aborts the query for hydrating the clients group, however the timeout is masked. Erchef does not return an error but actually an empty clients group. All this is masked from the client side user experience.

When the user goes to restore the ec backup they restore an empty clients group causing all sorts of authorization issues.

## Assumption
This PR assumes that the intention and correct behavior is that the clients group has ALL clients from the organization as members.

The ux looks like:

```
INFO: validating all clients for org brewinc exist in clients group
REPAIRING: Adding 5 missing clients into brewinc's client group file /Users/jmiller/Devel/ChefProject/chef-server-vagrant/backups/organizations/brewinc/groups/clients.json
```
Signed-off-by: Jeremy J. Miller <jm@chef.io>